### PR TITLE
[FIX] add invisible scenario_id field in scenario.step form

### DIFF
--- a/__openerp__.py
+++ b/__openerp__.py
@@ -24,7 +24,7 @@
 
 {
     'name': 'Stock Scanner',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Generic Modules/Inventory Control',
     'description': """Allows managing barcode readers with simple scenarios
 - You can define a workfow for each object (stock picking, inventory, sale, etc)

--- a/stock_scanner_view.xml
+++ b/stock_scanner_view.xml
@@ -168,6 +168,7 @@
                                         <field name="step_start"/>
                                         <field name="step_stop"/>
                                         <field name="step_back"/>
+                                        <field name="scenario_id" invisible="True" />
                                     </group>
                                     <notebook colspan="4">
                                         <page string="Transition">


### PR DESCRIPTION
This prevents a crash when one tries to add a transition from within the scenario.step form popped up from a scenario form. 
