### PR TITLE
7.0_add_step_no_back_fix_transition_back

### DIFF
--- a/hardware/sentinel.py
+++ b/hardware/sentinel.py
@@ -131,13 +131,10 @@ class Sentinel(object):
         self.scenario_name = False
         try:
             ssh_data = os.environ['SSH_CONNECTION'].split(' ')
-            if ssh_data:
-                self.hardware_code = ssh_data[0]
-                self.scanner_check()
+            self.hardware_code = ssh_data[0]
+            self.scanner_check()
         except:
-            self.hardware_code = os.environ['HARDWARE_CODE']
-            if not self.hardware_code:
-                self.hardware_code = self._input_text(_('Autoconfiguration failed !\nPlease enter terminal code'))
+            self.hardware_code = self._input_text(_('Autoconfiguration failed !\nPlease enter terminal code'))
             self.scanner_check()
 
         # Resize window to terminal screen size

--- a/hardware/sentinel.py
+++ b/hardware/sentinel.py
@@ -131,10 +131,13 @@ class Sentinel(object):
         self.scenario_name = False
         try:
             ssh_data = os.environ['SSH_CONNECTION'].split(' ')
-            self.hardware_code = ssh_data[0]
-            self.scanner_check()
+            if ssh_data:
+                self.hardware_code = ssh_data[0]
+                self.scanner_check()
         except:
-            self.hardware_code = self._input_text(_('Autoconfiguration failed !\nPlease enter terminal code'))
+            self.hardware_code = os.environ['HARDWARE_CODE']
+            if not self.hardware_code:
+                self.hardware_code = self._input_text(_('Autoconfiguration failed !\nPlease enter terminal code'))
             self.scanner_check()
 
         # Resize window to terminal screen size

--- a/stock_scanner.py
+++ b/stock_scanner.py
@@ -548,12 +548,28 @@ class scanner_hardware(osv.Model):
 
         tracer = False
 
-        if transition_type == 'restart' or scenario_id and step_id is None:
+        if transition_type == 'back' and scenario_id:
+            if terminal.step_id.no_back:
+                step_id = terminal.step_id.id
+            elif terminal.previous_steps_id:
+                previous_steps_id = terminal.previous_steps_id.split(',')
+                previous_steps_message = terminal.previous_steps_message.split('\n')
+                if not previous_steps_id:
+                    return self.scanner_end(cr, uid, numterm=terminal.code, context=context)
+                step_id = int(previous_steps_id.pop())
+                terminal.previous_steps_id = ','.join(previous_steps_id)
+                message = eval(previous_steps_message.pop())
+                terminal.previous_steps_message = '\n'.join(previous_steps_message)
+            else:
+                scenario_id = False
+                message = terminal.scenario_id.name
+
+        elif transition_type == 'restart' or scenario_id and step_id is None:
             if terminal.previous_steps_id:
                 # Retrieve previous step id and message
                 previous_steps_id = terminal.previous_steps_id.split(',')
                 previous_steps_message = terminal.previous_steps_message.split('\n')
-                if transition_type != 'restart' and not terminal.step_id.no_back:
+                if transition_type != 'restart':
                     previous_steps_id.pop()
                     previous_steps_message.pop()
 
@@ -591,7 +607,7 @@ class scanner_hardware(osv.Model):
 
             else:
                 return self._send_error(cr, uid, [terminal_id], [_('Scenario'), _('not found')], context=context)
-        elif transition_type != 'none':
+        elif transition_type not in ('back', 'none'):
             # Retrieve outgoing transitions from the current step
             scanner_transition_obj = self.pool.get('scanner.scenario.transition')
             transition_ids = scanner_transition_obj.search(cr, uid, [('from_id', '=', step_id)], context=context)

--- a/stock_scanner.py
+++ b/stock_scanner.py
@@ -548,7 +548,7 @@ class scanner_hardware(osv.Model):
 
         tracer = False
 
-        if transition_type == 'back' and scenario_id:
+        if transition_type == 'restart' or transition_type == 'back' and scenario_id:
             if terminal.step_id.no_back:
                 step_id = terminal.step_id.id
             elif terminal.previous_steps_id:
@@ -558,29 +558,6 @@ class scanner_hardware(osv.Model):
                     return self.scanner_end(cr, uid, numterm=terminal.code, context=context)
                 step_id = int(previous_steps_id.pop())
                 terminal.previous_steps_id = ','.join(previous_steps_id)
-                message = eval(previous_steps_message.pop())
-                terminal.previous_steps_message = '\n'.join(previous_steps_message)
-            else:
-                scenario_id = False
-                message = terminal.scenario_id.name
-
-        elif transition_type == 'restart' or scenario_id and step_id is None:
-            if terminal.previous_steps_id:
-                # Retrieve previous step id and message
-                previous_steps_id = terminal.previous_steps_id.split(',')
-                previous_steps_message = terminal.previous_steps_message.split('\n')
-                if transition_type != 'restart':
-                    previous_steps_id.pop()
-                    previous_steps_message.pop()
-
-                if not previous_steps_id:
-                    return self.scanner_end(cr, uid, numterm=terminal.code, context=context)
-
-                # Retrieve step id
-                step_id = int(previous_steps_id.pop())
-                terminal.previous_steps_id = ','.join(previous_steps_id)
-
-                # Retrieve message
                 message = eval(previous_steps_message.pop())
                 terminal.previous_steps_message = '\n'.join(previous_steps_message)
             else:
@@ -607,7 +584,7 @@ class scanner_hardware(osv.Model):
 
             else:
                 return self._send_error(cr, uid, [terminal_id], [_('Scenario'), _('not found')], context=context)
-        elif transition_type not in ('back', 'none'):
+        elif transition_type not in ('back', 'none', 'restart'):
             # Retrieve outgoing transitions from the current step
             scanner_transition_obj = self.pool.get('scanner.scenario.transition')
             transition_ids = scanner_transition_obj.search(cr, uid, [('from_id', '=', step_id)], context=context)
@@ -638,7 +615,7 @@ class scanner_hardware(osv.Model):
                 tracer = transition.tracer
 
                 # Store the old step id if we are on a back step
-                if transition.to_id.step_back and terminal.previous_steps_id.split(',')[-1] != str(transition.from_id.id):
+                if transition.from_id.step_back and terminal.previous_steps_id.split(',')[-1] != str(transition.from_id.id):
                     terminal.previous_steps_message = terminal.previous_steps_id and '%s\n%s' % (terminal.previous_steps_message, repr(message)) or repr(message)
                     terminal.previous_steps_id = terminal.previous_steps_id and '%s,%d' % (terminal.previous_steps_id, transition.from_id.id) or str(transition.from_id.id)
 

--- a/stock_scanner.py
+++ b/stock_scanner.py
@@ -155,6 +155,7 @@ class scanner_scenario_step(osv.Model):
         'step_start': fields.boolean('Step start', help='Check this if this is the first step of the scenario'),
         'step_stop': fields.boolean('Step stop', help='Check this if this is the  last step of the scenario'),
         'step_back': fields.boolean('Step back', help='Check this to stop at this step when returning back'),
+        'no_back': fields.boolean('No back', help='Check this to prevent returning back this step'),
         'out_transition_ids': fields.one2many('scanner.scenario.transition', 'from_id', 'Outgoing transitons', ondelete='cascade', help='Transitions which goes to this step'),
         'in_transition_ids': fields.one2many('scanner.scenario.transition', 'to_id', 'Incoming transitions', ondelete='cascade', help='Transitions which goes to the next step'),
         'python_code': fields.text('Python code', help='Python code to execute'),
@@ -552,7 +553,7 @@ class scanner_hardware(osv.Model):
                 # Retrieve previous step id and message
                 previous_steps_id = terminal.previous_steps_id.split(',')
                 previous_steps_message = terminal.previous_steps_message.split('\n')
-                if transition_type != 'restart':
+                if transition_type != 'restart' and not terminal.step_id.no_back:
                     previous_steps_id.pop()
                     previous_steps_message.pop()
 

--- a/stock_scanner_view.xml
+++ b/stock_scanner_view.xml
@@ -158,6 +158,7 @@
                                     <field name="step_start"/>
                                     <field name="step_stop"/>
                                     <field name="step_back"/>
+                                    <field name="no_back"/>
                                 </tree>
                                 <form string="Step">
                                     <group colspan="4" col="6">
@@ -165,6 +166,7 @@
                                         <field name="step_start"/>
                                         <field name="step_stop"/>
                                         <field name="step_back"/>
+                                        <field name="no_back"/>
                                         <field name="scenario_id" invisible="True" />
                                     </group>
                                     <notebook colspan="4">
@@ -308,6 +310,7 @@
                     <field name="step_start"/>
                     <field name="step_stop"/>
                     <field name="step_back"/>
+                    <field name="no_back"/>
                 </search>
             </field>
         </record>
@@ -322,6 +325,7 @@
                     <field name="step_start"/>
                     <field name="step_stop"/>
                     <field name="step_back"/>
+                    <field name="no_back"/>
                 </tree>
             </field>
         </record>
@@ -337,7 +341,8 @@
                         <field name="step_start"/>
                         <field name="step_stop"/>
                         <field name="step_back"/>
-                        <newline/>
+                        <field name="no_back"/>
+                       <newline/>
                     </group>
                     <notebook colspan="4">
                         <page string="Code">


### PR DESCRIPTION
Hi,

In our scenario the workflow loops on a lot of steps. The first one is to select a product by ean..... To prevent that a 'back' transition return to an earlier step of the the first one, a new flag 'no_back' has been added on the step.

I've also modified the way transition_type is processed to avoid that a 'back' or 'restart' transition, replays the transitions BEFORE the step we want to go to. A 'back' or 'restart' transition put the workflow directly on the expected step. In the same time, I corrected when the identifier of the step is stored in the history of steps available for 'back' transition.

Regards,

lmi
